### PR TITLE
debug

### DIFF
--- a/src/backend/src/types.rs
+++ b/src/backend/src/types.rs
@@ -9,10 +9,15 @@ pub struct Snapshot {
 }
 impl ic_stable_structures::Storable for Snapshot {
     fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+        ic_cdk::println!("from_bytes");
+        ic_cdk::println!("{:x?}", bytes);
         Decode!(bytes.as_ref(), Self).unwrap()
     }
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        Cow::Owned(Encode!(self).unwrap())
+        let bytes = Encode!(self).unwrap();
+        ic_cdk::println!("to_bytes");
+        ic_cdk::println!("{:x?}", bytes);
+        Cow::Owned(bytes)
     }
 }
 impl ic_stable_structures::BoundedStorable for Snapshot {


### PR DESCRIPTION
```bash
% dfx canister call backend add_from_default
2024-01-10 12:03:40.792010 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] to_bytes
2024-01-10 12:03:40.792010 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] [44, 49, 44, 4c, 6, 6c, 2, f1, fe, e1, 8d, 3, 1, d6, a9, bb, ae, a, 78, 6c, 3, db, b7, 1, 71, dd, d1, 91, 44, 2, bd, d3, d1, ab, 6, 71, 6c, 7, f6, dc, b8, 81, 1, 3, 97, bc, 9b, 9a, 3, 75, f2, 9d, 80, ee, 4, 71, 97, ae, 9c, 8f, 9, 71, b4, e3, ad, e8, 9, 71, 82, b7, bd, e7, d, 71, e1, ea, f9, c8, f, 75, 6d, 4, 6c, 2, 0, 71, 1, 5, 6c, 5, b6, af, f5, dc, 2, 71, b7, 92, 93, fb, 2, 71, 94, ea, bf, b8, 3, 7e, d0, 8a, da, ff, 5, 71, b7, d8, 8f, f8, b, 71, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
()
% dfx canister call backend get_last_data --query
2024-01-10 12:03:43.985242 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] from_bytes
2024-01-10 12:03:43.985242 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] [44, 49, 44, 4c, 6, 6c, 2, f1, fe, e1, 8d, 3, 1, d6, a9, bb, ae, a, 78, 6c, 3, db, b7, 1, 71, dd, d1, 91, 44, 2, bd, d3, d1, ab, 6, 71, 6c, 7, f6, dc, b8, 81, 1, 3, 97, bc, 9b, 9a, 3, 75, f2, 9d, 80, ee, 4, 71, 97, ae, 9c, 8f, 9, 71, b4, e3, ad, e8, 9, 71, 82, b7, bd, e7, d, 71, e1, ea, f9, c8, f, 75, 6d, 4, 6c, 2, 0, 71, 1, 5, 6c, 5, b6, af, f5, dc, 2, 71, b7, 92, 93, fb, 2, 71, 94, ea, bf, b8, 3, 7e, d0, 8a, da, ff, 5, 71, b7, d8, 8f, f8, b, 71, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
(
  record {
    value = record {
      id = "";
      result = record {
        ticks = vec {};
        tick_current = 0 : int32;
        liquidity = "";
        token0 = "";
        address = "";
        sqrt_ratio_x96 = "";
        tick_spacing = 0 : int32;
      };
      jsonrpc = "";
    };
    timestamp = 0 : nat64;
  },
)
% dfx canister call backend add_from_dummy
2024-01-10 12:03:49.675502 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] to_bytes
2024-01-10 12:03:49.675502 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] [44, 49, 44, 4c, 6, 6c, 2, f1, fe, e1, 8d, 3, 1, d6, a9, bb, ae, a, 78, 6c, 3, db, b7, 1, 71, dd, d1, 91, 44, 2, bd, d3, d1, ab, 6, 71, 6c, 7, f6, dc, b8, 81, 1, 3, 97, bc, 9b, 9a, 3, 75, f2, 9d, 80, ee, 4, 71, 97, ae, 9c, 8f, 9, 71, b4, e3, ad, e8, 9, 71, 82, b7, bd, e7, d, 71, e1, ea, f9, c8, f, 75, 6d, 4, 6c, 2, 0, 71, 1, 5, 6c, 5, b6, af, f5, dc, 2, 71, b7, 92, 93, fb, 2, 71, 94, ea, bf, b8, 3, 7e, d0, 8a, da, ff, 5, 71, b7, d8, 8f, f8, b, 71, 1, 0, 1, 31, 0, 70, d1, fe, ff, 17, 30, 78, 31, 64, 32, 66, 30, 39, 31, 66, 66, 30, 39, 66, 62, 36, 37, 31, 37, 34, 37, 33, 38, 2a, 30, 78, 36, 62, 31, 37, 35, 34, 37, 34, 65, 38, 39, 30, 39, 34, 63, 34, 34, 64, 61, 39, 38, 62, 39, 35, 34, 65, 65, 64, 65, 61, 63, 34, 39, 35, 32, 37, 31, 64, 30, 66, 2a, 30, 78, 63, 32, 65, 39, 66, 32, 35, 62, 65, 36, 32, 35, 37, 63, 32, 31, 30, 64, 37, 61, 64, 66, 30, 64, 34, 63, 64, 36, 65, 33, 65, 38, 38, 31, 62, 61, 32, 35, 66, 38, 19, 30, 78, 35, 35, 33, 37, 36, 63, 64, 32, 61, 64, 30, 35, 62, 38, 31, 35, 37, 38, 30, 65, 63, 66, 62, 3c, 0, 0, 0, 3, 32, 2e, 30, a5, 87, 9e, 65, 0, 0, 0, 0]
()
% dfx canister call backend get_last_data --query
2024-01-10 12:03:51.564396 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] from_bytes
2024-01-10 12:03:51.564396 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] [44, 49, 44, 4c, 6, 6c, 2, f1, fe, e1, 8d, 3, 1, d6, a9, bb, ae, a, 78, 6c, 3, db, b7, 1, 71]
2024-01-10 12:03:51.564396 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] Panicked at 'called `Result::unwrap()` on an `Err` value: Custom(Cannot parse header 4449444c066c02f1fee18d0301d6a9bbae0a786c03dbb70171

Caused by:
    binary parser error: id at byte offset 25)', src/backend/src/types.rs:14:39
Error: Failed query call.
Caused by: Failed query call.
  The replica returned a replica error: reject code CanisterError, reject message IC0503: Canister bkyz2-fmaaa-aaaaa-qaaaq-cai trapped explicitly: Panicked at 'called `Result::unwrap()` on an `Err` value: Custom(Cannot parse header 4449444c066c02f1fee18d0301d6a9bbae0a786c03dbb70171

Caused by:
    binary parser error: id at byte offset 25)', src/backend/src/types.rs:14:39, error code Some("IC0503")
```